### PR TITLE
Resolving startup failure for spark-yarn-task

### DIFF
--- a/spark-yarn-task-app-dependencies/pom.xml
+++ b/spark-yarn-task-app-dependencies/pom.xml
@@ -15,7 +15,7 @@
     </parent>
 
 	<properties>
-		<spark.version>1.6.2</spark.version>
+		<spark.version>1.6.3</spark.version>
 		<spring-data-hadoop.version>2.4.0.RELEASE</spring-data-hadoop.version>
 	</properties>
 
@@ -32,27 +32,27 @@
 				<version>${spark.version}</version>
 				<exclusions>
 					<exclusion>
-						<groupId> org.apache.hadoop</groupId>
+						<groupId>org.apache.hadoop</groupId>
 						<artifactId>hadoop-client</artifactId>
 					</exclusion>
 					<exclusion>
-						<groupId> org.apache.hadoop</groupId>
+						<groupId>org.apache.hadoop</groupId>
 						<artifactId>hadoop-yarn-common</artifactId>
 					</exclusion>
 					<exclusion>
-						<groupId> org.apache.hadoop</groupId>
+						<groupId>org.apache.hadoop</groupId>
 						<artifactId>hadoop-yarn-client</artifactId>
 					</exclusion>
 					<exclusion>
-						<groupId> org.apache.hadoop</groupId>
+						<groupId>org.apache.hadoop</groupId>
 						<artifactId>hadoop-mapreduce-client-app</artifactId>
 					</exclusion>
 					<exclusion>
-						<groupId> org.apache.hadoop</groupId>
+						<groupId>org.apache.hadoop</groupId>
 						<artifactId>hadoop-yarn-server-web-proxy</artifactId>
 					</exclusion>
 					<exclusion>
-						<groupId> org.apache.hadoop</groupId>
+						<groupId>org.apache.hadoop</groupId>
 						<artifactId>hadoop-yarn-api</artifactId>
 					</exclusion>
 					<exclusion>
@@ -78,7 +78,7 @@
 			</dependency>
 		</dependencies>
     </dependencyManagement>
-<profiles>
+	<profiles>
 		<profile>
 			<id>spring</id>
 			<repositories>

--- a/spring-cloud-starter-task-spark-yarn/pom.xml
+++ b/spring-cloud-starter-task-spark-yarn/pom.xml
@@ -66,6 +66,12 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-hadoop-boot</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/spring-cloud-starter-task-spark-yarn/src/main/java/org/springframework/cloud/task/app/spark/yarn/SparkYarnEnvironmentPostProcessor.java
+++ b/spring-cloud-starter-task-spark-yarn/src/main/java/org/springframework/cloud/task/app/spark/yarn/SparkYarnEnvironmentPostProcessor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.task.app.spark.yarn;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+/**
+ * {@link EnvironmentPostProcessor} implementation that will disable the web environment that seems to be
+ * triggered by a Spark code dependency.
+ *
+ * @author Thomas Risberg
+ */
+public class SparkYarnEnvironmentPostProcessor implements EnvironmentPostProcessor {
+
+	@Override
+	public void postProcessEnvironment(ConfigurableEnvironment configurableEnvironment, SpringApplication springApplication) {
+		springApplication.setWebEnvironment(false);
+	}
+}

--- a/spring-cloud-starter-task-spark-yarn/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-starter-task-spark-yarn/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2017 the original author or authors.
+# Copyright 2017 the original author or authors.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -14,4 +14,4 @@
 #  limitations under the License.
 #
 
-configuration-properties.classes=org.springframework.cloud.task.app.spark.yarn.SparkYarnTaskProperties
+org.springframework.boot.env.EnvironmentPostProcessor=org.springframework.cloud.task.app.spark.yarn.SparkYarnEnvironmentPostProcessor


### PR DESCRIPTION
- adding EnvironmentPostProcessor to turn off web environment which seems to be triggered in newer Boot version by a Spark dependency

- updating to Spark 1.6.3

- removing obsolete referende to white-list property class for common properties

Resolves #2